### PR TITLE
Allow PSR-7 v1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -112,6 +112,9 @@ jobs:
           - "8.4"
         os:
           - "ubuntu-latest"
+        dependency-versions:
+          - "lowest"
+          - "highest"
 
     steps:
       - name: "Checkout repository"
@@ -125,6 +128,8 @@ jobs:
 
       - name: "Install dependencies (Composer)"
         uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "${{ matrix.dependency-versions }}"
 
       - name: "Run unit tests (PHPUnit)"
         run: "composer dev:test:unit"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "psr/http-client-implementation": "*",
         "psr/http-factory": "^1.1",
         "psr/http-factory-implementation": "*",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "rest-certain/hamcrest-phpunit": "^0.2.0",
         "symfony/filesystem": "^7.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "~8.3.0 || ~8.4.0",
         "dflydev/fig-cookies": "^3.1",
-        "league/uri": "^7.5",
+        "league/uri": "^7.5.1",
         "league/uri-components": "^7.5",
         "loilo/jsonpath": "^0.2.0",
         "mtdowling/jmespath.php": "^2.8",
@@ -37,7 +37,7 @@
     "require-dev": {
         "captainhook/captainhook": "^5.25",
         "captainhook/plugin-composer": "^5.3",
-        "ciareis/bypass": "^2.1.1",
+        "ciareis/bypass": "^2.1.2",
         "ergebnis/composer-normalize": "^2.47",
         "laminas/laminas-diactoros": "^3.6",
         "mockery/mockery": "^1.6",


### PR DESCRIPTION
Declare compatibility with psr/http-message v1 or v2.

## Description

Allow composer installation with PSR-7 v1 as well as v2.

## Motivation and context

There are, sadly, still various libraries that are only compatible with PSR-7 v1.   That includes, amazingly enough, ReactPHP's HTTP server.  I cannot run this library and those libraries at the same time unless one or the other becomes compatible with both versions.

## How has this been tested?

Let's see if CI complains?

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
